### PR TITLE
CMake: Rename mbed-os-ble-utils to mbed-ble-utils

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Copyright (c) 2020 ARM Limited. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-add_library(mbed-os-ble-utils INTERFACE)
+add_library(mbed-ble-utils INTERFACE)
 
-target_include_directories(mbed-os-ble-utils
+target_include_directories(mbed-ble-utils
     INTERFACE
         .
 )


### PR DESCRIPTION
- Rename library without mentioning OS keyword to follow the same name convention across Mbed OS libraries.

@paul-szczepanek-arm @0xc0170 