### PR TITLE
Deprecate pretty printer, update to use mbed-trace

### DIFF
--- a/ble_logging.cpp
+++ b/ble_logging.cpp
@@ -1,0 +1,105 @@
+/*
+ * Mbed-OS Microcontroller Library
+ * Copyright (c) 2020 Embedded Planet
+ * Copyright (c) 2020 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+#include "ble_logging.h"
+
+#define TRACE_GROUP BLE_UTILS_TRACE_GROUP
+
+void ble_log_error(ble_error_t error, const char *msg) {
+    switch(error) {
+        case BLE_ERROR_NONE:
+            tr_error("%s: BLE_ERROR_NONE: No error", msg);
+            break;
+        case BLE_ERROR_BUFFER_OVERFLOW:
+            tr_error("%s: BLE_ERROR_BUFFER_OVERFLOW: The requested action would cause a buffer overflow and has been aborted", msg);
+            break;
+        case BLE_ERROR_NOT_IMPLEMENTED:
+            tr_error("%s: BLE_ERROR_NOT_IMPLEMENTED: Requested a feature that isn't yet implement or isn't supported by the target HW", msg);
+            break;
+        case BLE_ERROR_PARAM_OUT_OF_RANGE:
+            tr_error("%s: BLE_ERROR_PARAM_OUT_OF_RANGE: One of the supplied parameters is outside the valid range", msg);
+            break;
+        case BLE_ERROR_INVALID_PARAM:
+            tr_error("%s: BLE_ERROR_INVALID_PARAM: One of the supplied parameters is invalid", msg);
+            break;
+        case BLE_STACK_BUSY:
+            tr_error("%s: BLE_STACK_BUSY: The stack is busy", msg);
+            break;
+        case BLE_ERROR_INVALID_STATE:
+            tr_error("%s: BLE_ERROR_INVALID_STATE: Invalid state", msg);
+            break;
+        case BLE_ERROR_NO_MEM:
+            tr_error("%s: BLE_ERROR_NO_MEM: Out of Memory", msg);
+            break;
+        case BLE_ERROR_OPERATION_NOT_PERMITTED:
+            tr_error("%s: BLE_ERROR_OPERATION_NOT_PERMITTED", msg);
+            break;
+        case BLE_ERROR_INITIALIZATION_INCOMPLETE:
+            tr_error("%s: BLE_ERROR_INITIALIZATION_INCOMPLETE", msg);
+            break;
+        case BLE_ERROR_ALREADY_INITIALIZED:
+            tr_error("%s: BLE_ERROR_ALREADY_INITIALIZED", msg);
+            break;
+        case BLE_ERROR_UNSPECIFIED:
+            tr_error("%s: BLE_ERROR_UNSPECIFIED: Unknown error", msg);
+            break;
+        case BLE_ERROR_INTERNAL_STACK_FAILURE:
+            tr_error("%s: BLE_ERROR_INTERNAL_STACK_FAILURE: internal stack failure", msg);
+            break;
+        case BLE_ERROR_NOT_FOUND:
+            tr_error("%s: BLE_ERROR_NOT_FOUND", msg);
+            break;
+        default:
+            tr_error("%s: Unknown error", msg);
+    }
+}
+
+void ble_log_address(const ble::address_t &addr) {
+    char mac_string[19];
+    ble_log_sprintf_address(mac_string, addr);
+    tr_info("%s", mac_string);
+}
+
+void ble_log_local_mac_address(BLE &ble) {
+    /* Print out device MAC address to the console*/
+    ble::own_address_type_t addr_type;
+    ble::address_t address;
+    char mac_string[19];
+    ble.gap().getAddress(addr_type, address);
+    ble_log_sprintf_address(mac_string, address);
+    tr_info("Device MAC address: %s", mac_string);
+}
+
+void ble_log_sprintf_address(char *buf, const ble::address_t &addr) {
+    snprintf(buf, 19, "%02x:%02x:%02x:%02x:%02x:%02x",
+            addr[5], addr[4], addr[3], addr[2], addr[1], addr[0]);
+}
+
+const char* phy_to_string(ble::phy_t phy) {
+    switch(phy.value()) {
+        case ble::phy_t::LE_1M:
+            return "LE 1M";
+        case ble::phy_t::LE_2M:
+            return "LE 2M";
+        case ble::phy_t::LE_CODED:
+            return "LE coded";
+        default:
+            return "invalid PHY";
+    }
+}

--- a/ble_logging.h
+++ b/ble_logging.h
@@ -1,0 +1,95 @@
+/*
+ * Mbed-OS Microcontroller Library
+ * Copyright (c) 2020 Embedded Planet
+ * Copyright (c) 2020 ARM Limited
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+
+#ifndef _BLE_LOGGING_H_
+#define _BLE_LOGGING_H_
+
+#include "ble/BLE.h"
+
+#include "mbed_trace.h"
+
+#define BLE_UTILS_TRACE_GROUP "bleP"
+
+/* Macros to avoid defining "bleP" in .tpp files,
+ * as these get included as headers essentially. This would cause
+ * redefinitions of TRACE_GROUP in files that include BLE framework headers
+ */
+#if MBED_TRACE_MAX_LEVEL >= TRACE_LEVEL_DEBUG
+#define ble_tr_debug(...)           mbed_tracef(TRACE_LEVEL_DEBUG,   BLE_UTILS_TRACE_GROUP, __VA_ARGS__)   //!< Print debug message
+#else
+#define ble_tr_debug(...)
+#endif
+
+#if MBED_TRACE_MAX_LEVEL >= TRACE_LEVEL_INFO
+#define ble_tr_info(...)            mbed_tracef(TRACE_LEVEL_INFO,    BLE_UTILS_TRACE_GROUP, __VA_ARGS__)   //!< Print info message
+#else
+#define ble_tr_info(...)
+#endif
+
+#if MBED_TRACE_MAX_LEVEL >= TRACE_LEVEL_WARN
+#define ble_tr_warning(...)         mbed_tracef(TRACE_LEVEL_WARN,    BLE_UTILS_TRACE_GROUP, __VA_ARGS__)   //!< Print warning message
+#define ble_tr_warn(...)            mbed_tracef(TRACE_LEVEL_WARN,    BLE_UTILS_TRACE_GROUP, __VA_ARGS__)   //!< Alternative warning message
+#else
+#define ble_tr_warning(...)
+#define ble_tr_warn(...)
+#endif
+
+#if MBED_TRACE_MAX_LEVEL >= TRACE_LEVEL_ERROR
+#define ble_tr_error(...)           mbed_tracef(TRACE_LEVEL_ERROR,   BLE_UTILS_TRACE_GROUP, __VA_ARGS__)   //!< Print Error Message
+#define ble_tr_err(...)             mbed_tracef(TRACE_LEVEL_ERROR,   BLE_UTILS_TRACE_GROUP, __VA_ARGS__)   //!< Alternative error message
+#else
+#define ble_tr_error(...)
+#define ble_tr_err(...)
+#endif
+
+/**
+ * Log a BLE error
+ * @param[in] error Error type to log
+ * @param[in] msg Message to prefix error log with
+ */
+void ble_log_error(ble_error_t error, const char *msg);
+
+/**
+ * Log a ble::address_t
+ * @param[in] addr Address to log
+ */
+void ble_log_address(const ble::address_t &addr);
+
+/**
+ * Log local device MAC address
+ */
+void ble_log_local_mac_address(BLE &ble);
+
+/**
+ * Print the given address into the given buffer.
+ * @param[in] buf Buffer to print address into
+ * @param[in] addr Address to print into buf
+ *
+ * @note buf must be at least 19 chars to ensure the whole address fits
+ */
+void ble_log_sprintf_address(char *buf, const ble::address_t &addr);
+
+/**
+ * Convert a ble::phy_t to its corresponding string representation
+ * @param[in] phy Phy to convert
+ * @retval String representation of phy
+ */
+const char* phy_to_string(ble::phy_t phy);
+
+#endif /* _BLE_LOGGING_H_ */

--- a/pretty_printer.h
+++ b/pretty_printer.h
@@ -20,86 +20,28 @@
 #include <mbed.h>
 #include "ble/BLE.h"
 
+#include "platform/mbed_toolchain.h"
+
+#warning "pretty_printer.h has been replaced with ble_logging.h. Please include that file instead."
+#include "ble_logging.h"
+
+MBED_DEPRECATED("print_error is deprecated. Use ble_log_error instead.")
 inline void print_error(ble_error_t error, const char* msg)
 {
-    printf("%s: ", msg);
-    switch(error) {
-        case BLE_ERROR_NONE:
-            printf("BLE_ERROR_NONE: No error");
-            break;
-        case BLE_ERROR_BUFFER_OVERFLOW:
-            printf("BLE_ERROR_BUFFER_OVERFLOW: The requested action would cause a buffer overflow and has been aborted");
-            break;
-        case BLE_ERROR_NOT_IMPLEMENTED:
-            printf("BLE_ERROR_NOT_IMPLEMENTED: Requested a feature that isn't yet implement or isn't supported by the target HW");
-            break;
-        case BLE_ERROR_PARAM_OUT_OF_RANGE:
-            printf("BLE_ERROR_PARAM_OUT_OF_RANGE: One of the supplied parameters is outside the valid range");
-            break;
-        case BLE_ERROR_INVALID_PARAM:
-            printf("BLE_ERROR_INVALID_PARAM: One of the supplied parameters is invalid");
-            break;
-        case BLE_STACK_BUSY:
-            printf("BLE_STACK_BUSY: The stack is busy");
-            break;
-        case BLE_ERROR_INVALID_STATE:
-            printf("BLE_ERROR_INVALID_STATE: Invalid state");
-            break;
-        case BLE_ERROR_NO_MEM:
-            printf("BLE_ERROR_NO_MEM: Out of Memory");
-            break;
-        case BLE_ERROR_OPERATION_NOT_PERMITTED:
-            printf("BLE_ERROR_OPERATION_NOT_PERMITTED");
-            break;
-        case BLE_ERROR_INITIALIZATION_INCOMPLETE:
-            printf("BLE_ERROR_INITIALIZATION_INCOMPLETE");
-            break;
-        case BLE_ERROR_ALREADY_INITIALIZED:
-            printf("BLE_ERROR_ALREADY_INITIALIZED");
-            break;
-        case BLE_ERROR_UNSPECIFIED:
-            printf("BLE_ERROR_UNSPECIFIED: Unknown error");
-            break;
-        case BLE_ERROR_INTERNAL_STACK_FAILURE:
-            printf("BLE_ERROR_INTERNAL_STACK_FAILURE: internal stack failure");
-            break;
-        case BLE_ERROR_NOT_FOUND:
-            printf("BLE_ERROR_NOT_FOUND");
-            break;
-        default:
-            printf("Unknown error");
-    }
-    printf("\r\n");
+    ble_log_error(error, msg);
 }
 
 /** print device address to the terminal */
+MBED_DEPRECATED("print_address is deprecated. Use ble_log_address instead")
 inline void print_address(const ble::address_t &addr)
 {
-    printf("%02x:%02x:%02x:%02x:%02x:%02x\r\n",
-           addr[5], addr[4], addr[3], addr[2], addr[1], addr[0]);
+    ble_log_address(addr);
 }
 
+MBED_DEPRECATED("print_mac_address is deprecated. Use ble_log_local_mac_address instead")
 inline void print_mac_address()
 {
-    /* Print out device MAC address to the console*/
-    ble::own_address_type_t addr_type;
-    ble::address_t address;
-    BLE::Instance().gap().getAddress(addr_type, address);
-    printf("DEVICE MAC ADDRESS: ");
-    print_address(address);
-}
-
-inline const char* phy_to_string(ble::phy_t phy) {
-    switch(phy.value()) {
-        case ble::phy_t::LE_1M:
-            return "LE 1M";
-        case ble::phy_t::LE_2M:
-            return "LE 2M";
-        case ble::phy_t::LE_CODED:
-            return "LE coded";
-        default:
-            return "invalid PHY";
-    }
+    ble_log_local_mac_address();
 }
 
 #endif /* PRETTY_PRINTER_H_ */


### PR DESCRIPTION
This commit deprecates the functions in pretty printer and replaces them with new versions in ble_logging that use the standard mbed-trace library for BLE utility logging.

A library should not use printf when a trace library is available that allows you to configure/enable/disable output. This prevents the debug output from being cluttered with unformatted debug messages from the BLE utility library.